### PR TITLE
Add nofollow and noopener to comment author links

### DIFF
--- a/snippets/comments.php
+++ b/snippets/comments.php
@@ -7,7 +7,7 @@
   <?php foreach ($comments as $comment): ?>
     <article id="comment-<?= $comment->id() ?>" class="comment<?php e($comment->isPreview(), ' preview"') ?>">
       <h3>
-        <?php e($comment->isLinkable(), "<a href='{$comment->website()}'>") ?>
+        <?php e($comment->isLinkable(), "<a rel='nofollow noopener' href='{$comment->website()}'>") ?>
         <?= $comment->name() ?>
         <?php e($comment->isLinkable(), "</a>") ?>
       </h3>


### PR DESCRIPTION
Setting `rel="nofollow noopener"` helps SEO and security. [`nofollow`](https://support.google.com/webmasters/answer/96569?hl=en) signals to search engines that the comment author's website isn't endorsed by your website, and `noopener` prevents a malicious page from exploiting a browser [security vulnerability](https://mathiasbynens.github.io/rel-noopener/).

MDN Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types