### PR TITLE
Decode special characters when echoing names

### DIFF
--- a/snippets/comments-list.php
+++ b/snippets/comments-list.php
@@ -22,7 +22,7 @@ $status = $comments->process();
     <article id="comment-<?= $comment->id() ?>" class="comment<?php e($comment->isPreview(), ' preview"') ?>">
       <h3>
         <?php e($comment->isLinkable(), "<a rel='nofollow noopener' href='{$comment->website()}'>") ?>
-        <?= $comment->name() ?>
+        <?= html_entity_decode($comment->name()) ?>
         <?php e($comment->isLinkable(), "</a>") ?>
       </h3>
       


### PR DESCRIPTION
Encoding the name's [html entities](https://github.com/Addpixel/KirbyComments/blob/master/plugin/Comment.php#L141) leads to issues with some names.

`Jörn` is echoed as : `J&ouml;rn`

`Julé` is echoed as : `Jul&eacute;`

This PR decodes those characters.

(unless there was a reason not to decode them ?)