### PR TITLE
Use Kirby’s email() function for sending comment notification emails

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -2,7 +2,7 @@
 
 /**
  * Kirby Comments
- *
+ * 
  * File-based comments stored as subpages.
  *
  * @package   Kirby Comments

--- a/comments.php
+++ b/comments.php
@@ -2,7 +2,7 @@
 
 /**
  * Kirby Comments
- * 
+ *
  * File-based comments stored as subpages.
  *
  * @package   Kirby Comments
@@ -50,6 +50,7 @@ Comments::init(array(
 	'honeypot.human-value'             => '',
 	'email.enabled'                    => false,
 	'email.to'                         => array(),
+	'email.from'                       => '',
 	'email.subject'                    => 'New Comment on {{ page.title }}',
 	'email.undefined-value'            => '(not specified)',
 	'session.key'                      => 'comments',

--- a/plugin/Comments.php
+++ b/plugin/Comments.php
@@ -2,16 +2,16 @@
 
 /**
  * Comments
- *
+ * 
  * The `Comments` class provides static methods to be accessed by its own
  * instances and other parts of the plugin. `Comments` instances manage the
  * comments of a specific Kirby page. This involves processing HTTP POST data
  * for creating comment previews, submitting comments, storing comments as
  * Kirby pages, reading those pages and reporting status.
- *
+ * 
  * `Comments` instances provide additional convenience methods for creating
  * comments forms.
- *
+ * 
  * The preferred way of creating and accessing `Comments` instances is by
  * calling `$page->comments()` where `$page` is a Kirby `Page` object.
  *
@@ -29,7 +29,7 @@ class Comments implements Iterator, Countable
 	 * @var mixed[string]
 	 */
 	private static $defaults = null;
-
+	
 	/**
 	 * Deprecated option names referenced by their new counterparts.
 	 *
@@ -53,7 +53,7 @@ class Comments implements Iterator, Countable
 		'honeypot.human-value'      => 'human-honeypot-value',
 		'setup.content-page.title'  => 'setup.page.title_key'
 	);
-
+	
 	/**
 	 * All instances created using `Comments::for_page($page)` (which is also used
 	 * by `$page->comments()`) referenced by the URI of the page.
@@ -61,14 +61,14 @@ class Comments implements Iterator, Countable
 	 * @var Comments[string]
 	 */
 	private static $instances = array();
-
+	
 	/**
 	 * Kirby page on which the comments are posted.
 	 *
 	 * @var Page
 	 */
 	private $page;
-
+	
 	/**
 	 * Status of the comments. Is modified during construction of a `Comments`
 	 * instance and which processing the comments using `$this->process()`.
@@ -76,14 +76,14 @@ class Comments implements Iterator, Countable
 	 * @var CommentsStatus
 	 */
 	private $status;
-
+	
 	/**
 	 * Whether `$this->process()` has been invoked.
 	 *
 	 * @var bool
 	 */
 	private $has_been_processed;
-
+	
 	/**
 	 * The index of the iterator. Used for the implementation of the `Iterator`
 	 * interface.
@@ -91,7 +91,7 @@ class Comments implements Iterator, Countable
 	 * @var integer
 	 */
 	private $iterator_index;
-
+	
 	/**
 	 * An array of comments on $this->page (published and unpublished).
 	 * All comments managed by a `Comments` instance. Is modified during
@@ -101,7 +101,7 @@ class Comments implements Iterator, Countable
 	 * @var Comment[]
 	 */
 	private $comments;
-
+	
 	/**
 	 * Whether the current comment preview is valid. `false` iff no preview is
 	 * requested.
@@ -109,28 +109,28 @@ class Comments implements Iterator, Countable
 	 * @var bool
 	 */
 	private $is_valid_preview;
-
+	
 	/**
 	 * Configures the plugin by setting default values and reading custom field
 	 * types from Kirby’s configuration. This static method will early exit if
 	 * called multiple times during a single HTTP request.
-	 *
+	 * 
 	 * @param mixed[string] $defaults
 	 */
 	static public function init($defaults)
 	{
 		// Early exit if this method has already been called during this request
 		if (Comments::$defaults !== null) { return; }
-
+		
 		// Store default options
 		Comments::$defaults = $defaults;
-
+		
 		// Register custom fields
 		CommentsFieldType::$instances = array_map(function ($instruction) {
 			return CommentsFieldType::from_array($instruction);
 		}, Comments::option('custom-fields'));
 	}
-
+	
 	/**
 	 * Returns a `Comments` instance for `$page`. Constructs a new instance
 	 * if no instance exists for the given page, returns a reference to an
@@ -145,21 +145,21 @@ class Comments implements Iterator, Countable
 	static public function for_page($page)
 	{
 		$uri = $page->uri();
-
+		
 		// Check for existing instance
 		if (array_key_exists($uri, Comments::$instances)) {
 			// Return existing instance
 			return Comments::$instances[$uri];
 		}
-
+		
 		// Construct new instance
 		$new_instance = new Comments($page);
 		Comments::$instances[$uri] = $new_instance;
-
+		
 		// Return new instance
 		return $new_instance;
 	}
-
+	
 	/**
 	 * Comments constructor. ATTENTION: the use of this constructor is DEPRECATED;
 	 * use `Comments::for_page($page)` or `$page->comments()` instead.
@@ -176,35 +176,35 @@ class Comments implements Iterator, Countable
 		$this->comments = array();
 		$this->is_valid_preview = false;
 		$this->has_been_processed = false;
-
+		
 		// Scan for existing comments
 		$comments_page_dirname = Comments::option('pages.comments.dirname');
 		$comments_page = $this->page->find($comments_page_dirname);
-
+		
 		// Check for existence of stored comments
 		if ($comments_page != null) {
 			foreach ($comments_page->children() as $comment_page) {
 				$this->comments[] = Comment::form_page($comment_page);
 			}
 		}
-
+		
 		// A session is needed for form validation and CSRF protection
 		if (session_status() === PHP_SESSION_NONE) {
 			session_start();
 		}
 	}
-
+	
 	//
 	// Options
 	//
-
+	
 	/**
 	 * This method provides convenient access to Kirby Comments’s options. Options
 	 * may be configured in Kirby’s configuration file. The default values for
 	 * all options are set in `Comments::init($defaults)`. All Kirby Comments
 	 * options are prefixed with `comments.`; the `$key` argument must not include
 	 * this prefix.
-	 *
+	 * 
 	 * Note that this method is used throughout the whole plugin.
 	 *
 	 * @param string $key
@@ -213,26 +213,26 @@ class Comments implements Iterator, Countable
 	public static function option($key)
 	{
 		$value = null;
-
+		
 		if (array_key_exists($key, Comments::$defaults)) {
 			$value = Comments::$defaults[$key];
 		}
-
+		
 		if (array_key_exists($key, Comments::$deprecated_keys)) {
 			// Check, whether a deprecated key was used to set a option. If `$tmp` is
 			// not equal to `$default_value` a value was set for a deprecated key.
 			$deprecated_key = Comments::$deprecated_keys[$key];
 			$default_value = null;
 			$tmp = c::get('comments.'.$deprecated_key, $default_value);
-
+			
 			if ($tmp !== $default_value) {
 				$value = $tmp;
 			}
 		}
-
+		
 		return c::get('comments.'.$key, $value);
 	}
-
+	
 	/**
 	 * Invokes a hook and returns its return value. Returns `null` if the hook is
 	 * undefined or `null`.
@@ -243,11 +243,11 @@ class Comments implements Iterator, Countable
 	 */
 	public static function invokeHook($hook_name, $arguments) {
 		$hook = Comments::option('hooks.'.$hook_name);
-
+		
 		if ($hook !== null) {
 			return call_user_func_array($hook, $arguments);
 		}
-
+		
 		// Handle deprecation
 		if ($hook_name === 'get-content-page-title' && c::get('comments.setup.page.title_key', null) !== null) {
 			$title_key = c::get('comments.setup.page.title_key');
@@ -261,20 +261,20 @@ class Comments implements Iterator, Countable
 			$f = c::get('comments.pages.comments.title');
 			return $f($arguments[0]);
 		}
-
+		
 		return null;
-	}
-
+	} 
+	
 	//
 	// Process Comment
 	//
-
+	
 	/**
 	 * Processes comments based on the HTTP POST data of the HTTP request. This
 	 * involves generating preview comments, storing published comments as
 	 * Kirby pages, creating comments pages, validating user data and sending
 	 * email notifications.
-	 *
+	 * 
 	 * This method may be called multiple times during a single HTTP request but
 	 * execute only once. On repeated calls, the current status object is
 	 * returned.
@@ -286,52 +286,52 @@ class Comments implements Iterator, Countable
 		// Early exit of repeated calls
 		if ($this->has_been_processed) { return $this->status; }
 		$this->has_been_processed = true;
-
+		
 		// Return on error
 		if ($this->status->isError()) { return $this->status; }
-
+		
 		$is_preview = isset($_POST[Comments::option('form.preview')]);
 		$is_submit  = isset($_POST[Comments::option('form.submit')]);
 		$is_send    = $is_preview || $is_submit;
-
+		
 		// Check whether the session ID equals the posted session ID
 		if ($is_submit) {
 			$session_id = $_SESSION[Comments::option('session.key')];
 			$post_session_id = $_POST[Comments::option('form.session_id')];
-
+			
 			if ($session_id !== $post_session_id) {
 				$this->status = new CommentsStatus(300);
 				return $this->status;
 			}
 		}
-
+		
 		//
 		// Session is valid
 		//
-
+		
 		// Generate new session ID
 		$license_substring = substr(c::get('license'), 0, 6);
 		$new_session_id = md5(uniqid('comments_session_id').$license_substring);
 		$_SESSION[Comments::option('session.key')] = $new_session_id;
-
+		
 		if (!$is_send) {
 			// No preview request, no submission request:
 			return $this->status;
 		}
-
+		
 		// Find comments page
 		$comments_page_dirname = Comments::option('pages.comments.dirname');
 		$comments_page = $this->page->find($comments_page_dirname);
-
+		
 		// Store current time in a variable so that it is guaranteed to be the
 		// exact same point in time throughout the execution of this method.
 		$now = new DateTime();
-
+		
 		// Prepare new comment
 		$new_comment = null;
 		$comment_page = null;
 		$new_comment_id = $this->nextCommentId();
-
+		
 		try {
 			// Try constructing a `Comment` from the current POST data
 			$new_comment = Comment::from_post($this->page, $new_comment_id, $now);
@@ -340,7 +340,7 @@ class Comments implements Iterator, Countable
 			$this->status = new CommentsStatus($e->getCode(), $e);
 			return $this->status;
 		}
-
+		
 		// Block comment hook
 		try {
 			if (Comments::invokeHook('decide-block-comment', array($this, $new_comment))) {
@@ -350,7 +350,7 @@ class Comments implements Iterator, Countable
 			$this->status = new CommentsStatus($e->getCode(), $e);
 			return $this->status;
 		}
-
+		
 		if ($comments_page == null) {
 			// No comment was posted on `$this->page` yet; create comments page
 			try {
@@ -368,7 +368,7 @@ class Comments implements Iterator, Countable
 				$this->status = new CommentsStatus(200, $e);
 				return $this->status;
 			}
-
+			
 			try {
 				Comments::invokeHook('did-create-comments-page', array($this, $comments_page));
 			} catch (Exception $e) {
@@ -376,26 +376,26 @@ class Comments implements Iterator, Countable
 				return $this->status;
 			}
 		}
-
+		
 		if ($is_submit) {
 			// The comment author has submitted the comment; store it as page
 			try {
 				$dirname = Comments::option('pages.comment.dirname').'-'.$new_comment_id;
-
+				
 				if (Comments::option('pages.comment.visible')) {
 					// Add index to dirname to make the comment visible
 					$dirname =  $new_comment_id.'-'.$dirname;
 				}
-
+				
 				$template = Comments::option('pages.comment.template');
-
+				
 				// Save main fields
 				$contents = array(
 					'cid'  => $new_comment_id,
 					'date' => $new_comment->date('Y-m-d H:i:s'),
 					'text' => $new_comment->rawMessage()
 				);
-
+				
 				if ($new_comment->rawName() !== null) {
 					$contents['name'] = $new_comment->rawName();
 				}
@@ -405,20 +405,20 @@ class Comments implements Iterator, Countable
 				if ($new_comment->rawWebsite() !== null) {
 					$contents['website'] = $new_comment->rawWebsite();
 				}
-
+				
 				// Save custom fields
 				$custom_fields = $new_comment->customFields();
-
+				
 				if (count($custom_fields) > 0) {
 					$custom_fields_data = array();
-
+					
 					foreach ($new_comment->customFields() as $field) {
 						$custom_fields_data[$field->name()] = $field->value();
 					}
-
+					
 					$contents['customfields'] = yaml::encode($custom_fields_data);
 				}
-
+				
 				// Save comment as page
 				$comment_page = $comments_page->children()->create(
 					$dirname,
@@ -429,11 +429,11 @@ class Comments implements Iterator, Countable
 				$this->status =  new CommentsStatus(201, $e);
 				return $this->status;
 			}
-
+			
 			//
 			// Comment has been saved
 			//
-
+			
 			// Did save comment hook
 			try {
 				Comments::invokeHook('did-save-comment', array($this, $new_comment, $comment_page));
@@ -441,7 +441,7 @@ class Comments implements Iterator, Countable
 				$this->status = new CommentsStatus($e->getCode(), $e);
 				return $this->status;
 			}
-
+			
 			if (Comments::option('email.enabled')) {
 				// Send email notifications
 				$email = new CommentsEmail(
@@ -451,19 +451,19 @@ class Comments implements Iterator, Countable
 					$new_comment
 				);
 				$email_status = $email->send();
-
+				
 				if ($email_status->isError()) {
 					$this->status = $email_status;
 				}
 			}
 		}
-
+		
 		// Add the new comment to the list
 		$this->comments[] = $new_comment;
-
+		
 		if ($is_preview) {
 			$this->is_valid_preview = true;
-
+			
 			// Did preview comment hook
 			try {
 				Comments::invokeHook('did-preview-comment', array($this, $new_comment));
@@ -472,14 +472,14 @@ class Comments implements Iterator, Countable
 				return $this->status;
 			}
 		}
-
+		
 		return $this->status;
 	}
-
+	
 	//
 	// Comments List
 	//
-
+	
 	/**
 	 * `true` iff no comment is managed by this `Comments` instance.
 	 *
@@ -489,7 +489,7 @@ class Comments implements Iterator, Countable
 	{
 		return count($this->comments) === 0;
 	}
-
+	
 	/**
 	 * Number of comments managed by this `Comments` instance.
 	 *
@@ -499,11 +499,11 @@ class Comments implements Iterator, Countable
 	{
 		return count($this->comments);
 	}
-
+	
 	//
 	// Form
 	//
-
+	
 	/**
 	 * The ID of the preview comment in case of a preview; the ID of the next, as
 	 * of yet unwritten, comment otherwise. IDs start at 1 and increment on a per-
@@ -516,13 +516,13 @@ class Comments implements Iterator, Countable
 		$stored_comments = array_filter($this->comments, function ($comment) {
 			return $comment->isPreview() === false;
 		});
-
+		
 		if (count($stored_comments) > 0) {
 			return $stored_comments[count($stored_comments) - 1]->id() + 1;
 		}
 		return 1;
 	}
-
+	
 	/**
 	 * `true` iff the user has submitted a comment and no errors occurred.
 	 *
@@ -532,10 +532,10 @@ class Comments implements Iterator, Countable
 	{
 		$is_success = $this->status->isSuccess();
 		$is_submit = isset($_POST[Comments::option('form.submit')]);
-
+		
 		return $is_success && $is_submit;
 	}
-
+	
 	/**
 	 * `true` iff the user has submitted a comment and no errors occurred.
 	 * ATTENTION: this method is DEPRECATED; use `$this->isSuccessfulSubmission()`
@@ -548,16 +548,16 @@ class Comments implements Iterator, Countable
 	{
 		return $this->isSuccessfulSubmission();
 	}
-
+	
 	/**
 	 * Returns the HTML-escaped value of the HTTP POST data with the name
 	 * `$name`.
-	 *
+	 * 
 	 * When a user submits a form, the page is reloaded and all fields in the
 	 * form are cleared. In order to keep the text that the user has typed into
 	 * the fields, you have to set the `value` attribute of all input fields to
 	 * the value which was transmitted by the forms request.
-	 *
+	 * 
 	 * This method helps you in doing so by returning `$default` if the form was
 	 * not submitted, or an HTML-escaped version of the value posted by the user.
 	 *
@@ -569,13 +569,13 @@ class Comments implements Iterator, Countable
 	{
 		$is_preview = isset($_POST[Comments::option('form.preview')]);
 		$is_submit = isset($_POST[Comments::option('form.submit')]);
-
+		
 		if (($is_preview || $is_submit) && isset($_POST[$name])) {
 			return htmlentities(trim($_POST[$name]));
 		}
 		return $default;
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for the name field.
 	 *
@@ -586,7 +586,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->nameName(), $default);
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for the email field.
 	 *
@@ -597,7 +597,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->emailName(), $default);
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for the website field.
 	 *
@@ -608,7 +608,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->websiteName(), $default);
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for the message field.
 	 *
@@ -619,7 +619,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->messageName(), $default);
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for custom fields.
 	 *
@@ -631,7 +631,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->customFieldName($field_name), $default);
 	}
-
+	
 	/**
 	 * Convenience method for accessing `$this->value()` for the honeypot field.
 	 *
@@ -642,7 +642,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->honeypotName(), $default);
 	}
-
+	
 	/**
 	 * HTTP POST name of the submit button. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -653,7 +653,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.submit');
 	}
-
+	
 	/**
 	 * HTTP POST name of the preview button. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -664,7 +664,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.preview');
 	}
-
+	
 	/**
 	 * HTTP POST name of the name field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute.
@@ -675,7 +675,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name');
 	}
-
+	
 	/**
 	 * HTTP POST name of the email field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute.
@@ -686,7 +686,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email');
 	}
-
+	
 	/**
 	 * HTTP POST name of the website field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -697,7 +697,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.website');
 	}
-
+	
 	/**
 	 * HTTP POST name of the message field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -708,7 +708,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.message');
 	}
-
+	
 	/**
 	 * HTTP POST name of a custom field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute. `null` iff no custom
@@ -720,13 +720,13 @@ class Comments implements Iterator, Countable
 	public function customFieldName($field_name)
 	{
 		$type = CommentsFieldType::named($field_name);
-
+		
 		if ($type !== null) {
 			return $type->httpPostName();
 		}
 		return null;
 	}
-
+	
 	/**
 	 * HTTP POST name of the honeypot field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -737,7 +737,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.honeypot');
 	}
-
+	
 	/**
 	 * HTTP POST name of the session ID field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -748,7 +748,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.session_id');
 	}
-
+	
 	/**
 	 * `true` iff the honeypot mechanism is enabled.
 	 *
@@ -758,7 +758,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('honeypot.enabled');
 	}
-
+	
 	/**
 	 * `true` iff a comment author has to provide an email address.
 	 *
@@ -768,7 +768,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name.required');
 	}
-
+	
 	/**
 	 * `true` iff a comment author has to provide an email address.
 	 *
@@ -778,7 +778,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email.required');
 	}
-
+	
 	/**
 	 * `true` iff a comment author has to provide a value for the custom field.
 	 *
@@ -788,13 +788,13 @@ class Comments implements Iterator, Countable
 	public function requiresCustomField($field_name)
 	{
 		$type = CommentsFieldType::named($field_name);
-
+		
 		if ($type !== null) {
 			return $type->isRequired();
 		}
 		return false;
 	}
-
+	
 	/**
 	 * `true` iff a comment author must provide an email address. ATTENTION: this
 	 * method is DEPRECATED, use `$this->requiresEmailAddress()` instead.
@@ -805,7 +805,7 @@ class Comments implements Iterator, Countable
 	public function requireEmailAddress() {
 		return $this->requiresEmailAddress();
 	}
-
+	
 	/**
 	 * Maximum allowed number of characters in the comment’s name field.
 	 *
@@ -815,7 +815,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name.max-length');
 	}
-
+	
 	/**
 	 * Maximum allowed number of characters in the comment’s email field.
 	 *
@@ -825,7 +825,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email.max-length');
 	}
-
+	
 	/**
 	 * Maximum allowed number of characters in the comment’s website field.
 	 *
@@ -835,7 +835,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.website.max-length');
 	}
-
+	
 	/**
 	 * Maximum allowed number of characters in the comment’s message field.
 	 *
@@ -845,7 +845,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.message.max-length');
 	}
-
+	
 	/**
 	 * Maximum allowed number of characters in the comment’s name field.
 	 * ATTENTION: this method is DEPRECATED, use `$this->nameMaxLength()`,
@@ -859,7 +859,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->nameMaxLength();
 	}
-
+	
 	/**
 	 * ID of the current comments session.
 	 *
@@ -869,7 +869,7 @@ class Comments implements Iterator, Countable
 	{
 		return $_SESSION[Comments::option('session.key')];
 	}
-
+	
 	/**
 	 * `true` iff the current request is a preview and the preview is valid.
 	 *
@@ -879,7 +879,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->is_valid_preview;
 	}
-
+	
 	/**
 	 * `true` iff the current request is a preview and the preview is valid.
 	 * ATTENTION: this method is DEPRECATED, use `$this->isValidPreview()`
@@ -892,11 +892,11 @@ class Comments implements Iterator, Countable
 	{
 		return $this->isValidPreview();
 	}
-
+	
 	//
 	// Converter
 	//
-
+	
 	/**
 	 * Returns the comments managed by this `Comments` instance sorted in
 	 * chronological order.
@@ -907,19 +907,19 @@ class Comments implements Iterator, Countable
 	{
 		return $this->comments;
 	}
-
+	
 	/**
 	 * Nests comments based on a reference-to-anchor relationship.
-	 *
+	 * 
 	 * The anchor must be unique for every comment while zero or more references
 	 * may point to the same anchor. A comment is added as a child iff its
 	 * reference matches the anchor of another comment. A comment may not
 	 * reference its own anchor. If the reference of a comment does not match any
 	 * anchor it is placed at the top level.
-	 *
+	 * 
 	 * If `$reference_field` or `$anchor_field` are `null`, the comment’s ID is
 	 * used instead.
-	 *
+	 * 
 	 * By default, the string value of the reference and the anchor are compared.
 	 * Set `$compare_stringvalue` to `false` to compare the original values.
 	 *
@@ -934,35 +934,35 @@ class Comments implements Iterator, Countable
 		$nested_comments = array();
 		/** @var NestedComment[mixed] */
 		$labeled_comments = array();
-
+		
 		foreach ($this->comments as $comment) {
 			$anchor = $anchor_field === null ? $comment->id() : $comment->customField($anchor_field);
 			if ($anchor === null) { continue; }
 			if ($compare_stringvalue) { $anchor = strval($anchor); }
-
+			
 			$labeled_comments[$anchor] = new NestedComment($comment);
 		}
-
+		
 		foreach ($this->comments as $comment) {
 			$anchor = $anchor_field === null ? $comment->id() : $comment->customField($anchor_field);
 			if ($anchor === null) { continue; }
 			$reference = $reference_field === null ? $comment->id() : $comment->customField($reference_field);
 			if ($compare_stringvalue) { $reference = strval($reference); }
-
+			
 			if ($reference !== null && isset($labeled_comments[$reference])) {
 				$labeled_comments[$reference]->addChild($labeled_comments[$anchor]);
 			} else {
 				$nested_comments[] = $labeled_comments[$anchor];
 			}
 		}
-
+		
 		return $nested_comments;
 	}
-
+	
 	//
 	// Properties
 	//
-
+	
 	/**
 	 * Kirby page on which the comments are posted.
 	 *
@@ -972,34 +972,34 @@ class Comments implements Iterator, Countable
 	{
 		return $this->page;
 	}
-
+	
 	//
 	// Iterator
 	//
-
+	
 	function rewind()
 	{
 		$this->iterator_index = 0;
 	}
-
+	
 	function current()
 	{
 		return $this->comments[$this->iterator_index];
 	}
-
+	
 	function key()
 	{
 		return $this->iterator_index;
 	}
-
+	
 	function next()
 	{
 		$this->iterator_index += 1;
 	}
-
+	
 	function valid()
 	{
 		return isset($this->comments[$this->iterator_index]);
 	}
-
+	
 }

--- a/plugin/Comments.php
+++ b/plugin/Comments.php
@@ -2,16 +2,16 @@
 
 /**
  * Comments
- * 
+ *
  * The `Comments` class provides static methods to be accessed by its own
  * instances and other parts of the plugin. `Comments` instances manage the
  * comments of a specific Kirby page. This involves processing HTTP POST data
  * for creating comment previews, submitting comments, storing comments as
  * Kirby pages, reading those pages and reporting status.
- * 
+ *
  * `Comments` instances provide additional convenience methods for creating
  * comments forms.
- * 
+ *
  * The preferred way of creating and accessing `Comments` instances is by
  * calling `$page->comments()` where `$page` is a Kirby `Page` object.
  *
@@ -29,7 +29,7 @@ class Comments implements Iterator, Countable
 	 * @var mixed[string]
 	 */
 	private static $defaults = null;
-	
+
 	/**
 	 * Deprecated option names referenced by their new counterparts.
 	 *
@@ -53,7 +53,7 @@ class Comments implements Iterator, Countable
 		'honeypot.human-value'      => 'human-honeypot-value',
 		'setup.content-page.title'  => 'setup.page.title_key'
 	);
-	
+
 	/**
 	 * All instances created using `Comments::for_page($page)` (which is also used
 	 * by `$page->comments()`) referenced by the URI of the page.
@@ -61,14 +61,14 @@ class Comments implements Iterator, Countable
 	 * @var Comments[string]
 	 */
 	private static $instances = array();
-	
+
 	/**
 	 * Kirby page on which the comments are posted.
 	 *
 	 * @var Page
 	 */
 	private $page;
-	
+
 	/**
 	 * Status of the comments. Is modified during construction of a `Comments`
 	 * instance and which processing the comments using `$this->process()`.
@@ -76,14 +76,14 @@ class Comments implements Iterator, Countable
 	 * @var CommentsStatus
 	 */
 	private $status;
-	
+
 	/**
 	 * Whether `$this->process()` has been invoked.
 	 *
 	 * @var bool
 	 */
 	private $has_been_processed;
-	
+
 	/**
 	 * The index of the iterator. Used for the implementation of the `Iterator`
 	 * interface.
@@ -91,7 +91,7 @@ class Comments implements Iterator, Countable
 	 * @var integer
 	 */
 	private $iterator_index;
-	
+
 	/**
 	 * An array of comments on $this->page (published and unpublished).
 	 * All comments managed by a `Comments` instance. Is modified during
@@ -101,7 +101,7 @@ class Comments implements Iterator, Countable
 	 * @var Comment[]
 	 */
 	private $comments;
-	
+
 	/**
 	 * Whether the current comment preview is valid. `false` iff no preview is
 	 * requested.
@@ -109,28 +109,28 @@ class Comments implements Iterator, Countable
 	 * @var bool
 	 */
 	private $is_valid_preview;
-	
+
 	/**
 	 * Configures the plugin by setting default values and reading custom field
 	 * types from Kirby’s configuration. This static method will early exit if
 	 * called multiple times during a single HTTP request.
-	 * 
+	 *
 	 * @param mixed[string] $defaults
 	 */
 	static public function init($defaults)
 	{
 		// Early exit if this method has already been called during this request
 		if (Comments::$defaults !== null) { return; }
-		
+
 		// Store default options
 		Comments::$defaults = $defaults;
-		
+
 		// Register custom fields
 		CommentsFieldType::$instances = array_map(function ($instruction) {
 			return CommentsFieldType::from_array($instruction);
 		}, Comments::option('custom-fields'));
 	}
-	
+
 	/**
 	 * Returns a `Comments` instance for `$page`. Constructs a new instance
 	 * if no instance exists for the given page, returns a reference to an
@@ -145,21 +145,21 @@ class Comments implements Iterator, Countable
 	static public function for_page($page)
 	{
 		$uri = $page->uri();
-		
+
 		// Check for existing instance
 		if (array_key_exists($uri, Comments::$instances)) {
 			// Return existing instance
 			return Comments::$instances[$uri];
 		}
-		
+
 		// Construct new instance
 		$new_instance = new Comments($page);
 		Comments::$instances[$uri] = $new_instance;
-		
+
 		// Return new instance
 		return $new_instance;
 	}
-	
+
 	/**
 	 * Comments constructor. ATTENTION: the use of this constructor is DEPRECATED;
 	 * use `Comments::for_page($page)` or `$page->comments()` instead.
@@ -176,35 +176,35 @@ class Comments implements Iterator, Countable
 		$this->comments = array();
 		$this->is_valid_preview = false;
 		$this->has_been_processed = false;
-		
+
 		// Scan for existing comments
 		$comments_page_dirname = Comments::option('pages.comments.dirname');
 		$comments_page = $this->page->find($comments_page_dirname);
-		
+
 		// Check for existence of stored comments
 		if ($comments_page != null) {
 			foreach ($comments_page->children() as $comment_page) {
 				$this->comments[] = Comment::form_page($comment_page);
 			}
 		}
-		
+
 		// A session is needed for form validation and CSRF protection
 		if (session_status() === PHP_SESSION_NONE) {
 			session_start();
 		}
 	}
-	
+
 	//
 	// Options
 	//
-	
+
 	/**
 	 * This method provides convenient access to Kirby Comments’s options. Options
 	 * may be configured in Kirby’s configuration file. The default values for
 	 * all options are set in `Comments::init($defaults)`. All Kirby Comments
 	 * options are prefixed with `comments.`; the `$key` argument must not include
 	 * this prefix.
-	 * 
+	 *
 	 * Note that this method is used throughout the whole plugin.
 	 *
 	 * @param string $key
@@ -213,26 +213,26 @@ class Comments implements Iterator, Countable
 	public static function option($key)
 	{
 		$value = null;
-		
+
 		if (array_key_exists($key, Comments::$defaults)) {
 			$value = Comments::$defaults[$key];
 		}
-		
+
 		if (array_key_exists($key, Comments::$deprecated_keys)) {
 			// Check, whether a deprecated key was used to set a option. If `$tmp` is
 			// not equal to `$default_value` a value was set for a deprecated key.
 			$deprecated_key = Comments::$deprecated_keys[$key];
 			$default_value = null;
 			$tmp = c::get('comments.'.$deprecated_key, $default_value);
-			
+
 			if ($tmp !== $default_value) {
 				$value = $tmp;
 			}
 		}
-		
+
 		return c::get('comments.'.$key, $value);
 	}
-	
+
 	/**
 	 * Invokes a hook and returns its return value. Returns `null` if the hook is
 	 * undefined or `null`.
@@ -243,11 +243,11 @@ class Comments implements Iterator, Countable
 	 */
 	public static function invokeHook($hook_name, $arguments) {
 		$hook = Comments::option('hooks.'.$hook_name);
-		
+
 		if ($hook !== null) {
 			return call_user_func_array($hook, $arguments);
 		}
-		
+
 		// Handle deprecation
 		if ($hook_name === 'get-content-page-title' && c::get('comments.setup.page.title_key', null) !== null) {
 			$title_key = c::get('comments.setup.page.title_key');
@@ -261,20 +261,20 @@ class Comments implements Iterator, Countable
 			$f = c::get('comments.pages.comments.title');
 			return $f($arguments[0]);
 		}
-		
+
 		return null;
-	} 
-	
+	}
+
 	//
 	// Process Comment
 	//
-	
+
 	/**
 	 * Processes comments based on the HTTP POST data of the HTTP request. This
 	 * involves generating preview comments, storing published comments as
 	 * Kirby pages, creating comments pages, validating user data and sending
 	 * email notifications.
-	 * 
+	 *
 	 * This method may be called multiple times during a single HTTP request but
 	 * execute only once. On repeated calls, the current status object is
 	 * returned.
@@ -286,52 +286,52 @@ class Comments implements Iterator, Countable
 		// Early exit of repeated calls
 		if ($this->has_been_processed) { return $this->status; }
 		$this->has_been_processed = true;
-		
+
 		// Return on error
 		if ($this->status->isError()) { return $this->status; }
-		
+
 		$is_preview = isset($_POST[Comments::option('form.preview')]);
 		$is_submit  = isset($_POST[Comments::option('form.submit')]);
 		$is_send    = $is_preview || $is_submit;
-		
+
 		// Check whether the session ID equals the posted session ID
 		if ($is_submit) {
 			$session_id = $_SESSION[Comments::option('session.key')];
 			$post_session_id = $_POST[Comments::option('form.session_id')];
-			
+
 			if ($session_id !== $post_session_id) {
 				$this->status = new CommentsStatus(300);
 				return $this->status;
 			}
 		}
-		
+
 		//
 		// Session is valid
 		//
-		
+
 		// Generate new session ID
 		$license_substring = substr(c::get('license'), 0, 6);
 		$new_session_id = md5(uniqid('comments_session_id').$license_substring);
 		$_SESSION[Comments::option('session.key')] = $new_session_id;
-		
+
 		if (!$is_send) {
 			// No preview request, no submission request:
 			return $this->status;
 		}
-		
+
 		// Find comments page
 		$comments_page_dirname = Comments::option('pages.comments.dirname');
 		$comments_page = $this->page->find($comments_page_dirname);
-		
+
 		// Store current time in a variable so that it is guaranteed to be the
 		// exact same point in time throughout the execution of this method.
 		$now = new DateTime();
-		
+
 		// Prepare new comment
 		$new_comment = null;
 		$comment_page = null;
 		$new_comment_id = $this->nextCommentId();
-		
+
 		try {
 			// Try constructing a `Comment` from the current POST data
 			$new_comment = Comment::from_post($this->page, $new_comment_id, $now);
@@ -340,7 +340,7 @@ class Comments implements Iterator, Countable
 			$this->status = new CommentsStatus($e->getCode(), $e);
 			return $this->status;
 		}
-		
+
 		// Block comment hook
 		try {
 			if (Comments::invokeHook('decide-block-comment', array($this, $new_comment))) {
@@ -350,7 +350,7 @@ class Comments implements Iterator, Countable
 			$this->status = new CommentsStatus($e->getCode(), $e);
 			return $this->status;
 		}
-		
+
 		if ($comments_page == null) {
 			// No comment was posted on `$this->page` yet; create comments page
 			try {
@@ -368,7 +368,7 @@ class Comments implements Iterator, Countable
 				$this->status = new CommentsStatus(200, $e);
 				return $this->status;
 			}
-			
+
 			try {
 				Comments::invokeHook('did-create-comments-page', array($this, $comments_page));
 			} catch (Exception $e) {
@@ -376,26 +376,26 @@ class Comments implements Iterator, Countable
 				return $this->status;
 			}
 		}
-		
+
 		if ($is_submit) {
 			// The comment author has submitted the comment; store it as page
 			try {
 				$dirname = Comments::option('pages.comment.dirname').'-'.$new_comment_id;
-				
+
 				if (Comments::option('pages.comment.visible')) {
 					// Add index to dirname to make the comment visible
 					$dirname =  $new_comment_id.'-'.$dirname;
 				}
-				
+
 				$template = Comments::option('pages.comment.template');
-				
+
 				// Save main fields
 				$contents = array(
 					'cid'  => $new_comment_id,
 					'date' => $new_comment->date('Y-m-d H:i:s'),
 					'text' => $new_comment->rawMessage()
 				);
-				
+
 				if ($new_comment->rawName() !== null) {
 					$contents['name'] = $new_comment->rawName();
 				}
@@ -405,20 +405,20 @@ class Comments implements Iterator, Countable
 				if ($new_comment->rawWebsite() !== null) {
 					$contents['website'] = $new_comment->rawWebsite();
 				}
-				
+
 				// Save custom fields
 				$custom_fields = $new_comment->customFields();
-				
+
 				if (count($custom_fields) > 0) {
 					$custom_fields_data = array();
-					
+
 					foreach ($new_comment->customFields() as $field) {
 						$custom_fields_data[$field->name()] = $field->value();
 					}
-					
+
 					$contents['customfields'] = yaml::encode($custom_fields_data);
 				}
-				
+
 				// Save comment as page
 				$comment_page = $comments_page->children()->create(
 					$dirname,
@@ -429,11 +429,11 @@ class Comments implements Iterator, Countable
 				$this->status =  new CommentsStatus(201, $e);
 				return $this->status;
 			}
-			
+
 			//
 			// Comment has been saved
 			//
-			
+
 			// Did save comment hook
 			try {
 				Comments::invokeHook('did-save-comment', array($this, $new_comment, $comment_page));
@@ -441,28 +441,29 @@ class Comments implements Iterator, Countable
 				$this->status = new CommentsStatus($e->getCode(), $e);
 				return $this->status;
 			}
-			
+
 			if (Comments::option('email.enabled')) {
 				// Send email notifications
 				$email = new CommentsEmail(
 					Comments::option('email.to'),
+					Comments::option('email.from'),
 					Comments::option('email.subject'),
 					$new_comment
 				);
 				$email_status = $email->send();
-				
+
 				if ($email_status->isError()) {
 					$this->status = $email_status;
 				}
 			}
 		}
-		
+
 		// Add the new comment to the list
 		$this->comments[] = $new_comment;
-		
+
 		if ($is_preview) {
 			$this->is_valid_preview = true;
-			
+
 			// Did preview comment hook
 			try {
 				Comments::invokeHook('did-preview-comment', array($this, $new_comment));
@@ -471,14 +472,14 @@ class Comments implements Iterator, Countable
 				return $this->status;
 			}
 		}
-		
+
 		return $this->status;
 	}
-	
+
 	//
 	// Comments List
 	//
-	
+
 	/**
 	 * `true` iff no comment is managed by this `Comments` instance.
 	 *
@@ -488,7 +489,7 @@ class Comments implements Iterator, Countable
 	{
 		return count($this->comments) === 0;
 	}
-	
+
 	/**
 	 * Number of comments managed by this `Comments` instance.
 	 *
@@ -498,11 +499,11 @@ class Comments implements Iterator, Countable
 	{
 		return count($this->comments);
 	}
-	
+
 	//
 	// Form
 	//
-	
+
 	/**
 	 * The ID of the preview comment in case of a preview; the ID of the next, as
 	 * of yet unwritten, comment otherwise. IDs start at 1 and increment on a per-
@@ -515,13 +516,13 @@ class Comments implements Iterator, Countable
 		$stored_comments = array_filter($this->comments, function ($comment) {
 			return $comment->isPreview() === false;
 		});
-		
+
 		if (count($stored_comments) > 0) {
 			return $stored_comments[count($stored_comments) - 1]->id() + 1;
 		}
 		return 1;
 	}
-	
+
 	/**
 	 * `true` iff the user has submitted a comment and no errors occurred.
 	 *
@@ -531,10 +532,10 @@ class Comments implements Iterator, Countable
 	{
 		$is_success = $this->status->isSuccess();
 		$is_submit = isset($_POST[Comments::option('form.submit')]);
-		
+
 		return $is_success && $is_submit;
 	}
-	
+
 	/**
 	 * `true` iff the user has submitted a comment and no errors occurred.
 	 * ATTENTION: this method is DEPRECATED; use `$this->isSuccessfulSubmission()`
@@ -547,16 +548,16 @@ class Comments implements Iterator, Countable
 	{
 		return $this->isSuccessfulSubmission();
 	}
-	
+
 	/**
 	 * Returns the HTML-escaped value of the HTTP POST data with the name
 	 * `$name`.
-	 * 
+	 *
 	 * When a user submits a form, the page is reloaded and all fields in the
 	 * form are cleared. In order to keep the text that the user has typed into
 	 * the fields, you have to set the `value` attribute of all input fields to
 	 * the value which was transmitted by the forms request.
-	 * 
+	 *
 	 * This method helps you in doing so by returning `$default` if the form was
 	 * not submitted, or an HTML-escaped version of the value posted by the user.
 	 *
@@ -568,13 +569,13 @@ class Comments implements Iterator, Countable
 	{
 		$is_preview = isset($_POST[Comments::option('form.preview')]);
 		$is_submit = isset($_POST[Comments::option('form.submit')]);
-		
+
 		if (($is_preview || $is_submit) && isset($_POST[$name])) {
 			return htmlentities(trim($_POST[$name]));
 		}
 		return $default;
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for the name field.
 	 *
@@ -585,7 +586,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->nameName(), $default);
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for the email field.
 	 *
@@ -596,7 +597,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->emailName(), $default);
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for the website field.
 	 *
@@ -607,7 +608,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->websiteName(), $default);
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for the message field.
 	 *
@@ -618,7 +619,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->messageName(), $default);
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for custom fields.
 	 *
@@ -630,7 +631,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->customFieldName($field_name), $default);
 	}
-	
+
 	/**
 	 * Convenience method for accessing `$this->value()` for the honeypot field.
 	 *
@@ -641,7 +642,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->value($this->honeypotName(), $default);
 	}
-	
+
 	/**
 	 * HTTP POST name of the submit button. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -652,7 +653,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.submit');
 	}
-	
+
 	/**
 	 * HTTP POST name of the preview button. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -663,7 +664,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.preview');
 	}
-	
+
 	/**
 	 * HTTP POST name of the name field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute.
@@ -674,7 +675,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name');
 	}
-	
+
 	/**
 	 * HTTP POST name of the email field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute.
@@ -685,7 +686,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email');
 	}
-	
+
 	/**
 	 * HTTP POST name of the website field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -696,7 +697,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.website');
 	}
-	
+
 	/**
 	 * HTTP POST name of the message field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -707,7 +708,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.message');
 	}
-	
+
 	/**
 	 * HTTP POST name of a custom field. Used as the key for the HTTP POST data
 	 * and as the value of the HTML input `name` attribute. `null` iff no custom
@@ -719,13 +720,13 @@ class Comments implements Iterator, Countable
 	public function customFieldName($field_name)
 	{
 		$type = CommentsFieldType::named($field_name);
-		
+
 		if ($type !== null) {
 			return $type->httpPostName();
 		}
 		return null;
 	}
-	
+
 	/**
 	 * HTTP POST name of the honeypot field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -736,7 +737,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.honeypot');
 	}
-	
+
 	/**
 	 * HTTP POST name of the session ID field. Used as the key for the HTTP POST
 	 * data and as the value of the HTML input `name` attribute.
@@ -747,7 +748,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.session_id');
 	}
-	
+
 	/**
 	 * `true` iff the honeypot mechanism is enabled.
 	 *
@@ -757,7 +758,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('honeypot.enabled');
 	}
-	
+
 	/**
 	 * `true` iff a comment author has to provide an email address.
 	 *
@@ -767,7 +768,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name.required');
 	}
-	
+
 	/**
 	 * `true` iff a comment author has to provide an email address.
 	 *
@@ -777,7 +778,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email.required');
 	}
-	
+
 	/**
 	 * `true` iff a comment author has to provide a value for the custom field.
 	 *
@@ -787,13 +788,13 @@ class Comments implements Iterator, Countable
 	public function requiresCustomField($field_name)
 	{
 		$type = CommentsFieldType::named($field_name);
-		
+
 		if ($type !== null) {
 			return $type->isRequired();
 		}
 		return false;
 	}
-	
+
 	/**
 	 * `true` iff a comment author must provide an email address. ATTENTION: this
 	 * method is DEPRECATED, use `$this->requiresEmailAddress()` instead.
@@ -804,7 +805,7 @@ class Comments implements Iterator, Countable
 	public function requireEmailAddress() {
 		return $this->requiresEmailAddress();
 	}
-	
+
 	/**
 	 * Maximum allowed number of characters in the comment’s name field.
 	 *
@@ -814,7 +815,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.name.max-length');
 	}
-	
+
 	/**
 	 * Maximum allowed number of characters in the comment’s email field.
 	 *
@@ -824,7 +825,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.email.max-length');
 	}
-	
+
 	/**
 	 * Maximum allowed number of characters in the comment’s website field.
 	 *
@@ -834,7 +835,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.website.max-length');
 	}
-	
+
 	/**
 	 * Maximum allowed number of characters in the comment’s message field.
 	 *
@@ -844,7 +845,7 @@ class Comments implements Iterator, Countable
 	{
 		return Comments::option('form.message.max-length');
 	}
-	
+
 	/**
 	 * Maximum allowed number of characters in the comment’s name field.
 	 * ATTENTION: this method is DEPRECATED, use `$this->nameMaxLength()`,
@@ -858,7 +859,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->nameMaxLength();
 	}
-	
+
 	/**
 	 * ID of the current comments session.
 	 *
@@ -868,7 +869,7 @@ class Comments implements Iterator, Countable
 	{
 		return $_SESSION[Comments::option('session.key')];
 	}
-	
+
 	/**
 	 * `true` iff the current request is a preview and the preview is valid.
 	 *
@@ -878,7 +879,7 @@ class Comments implements Iterator, Countable
 	{
 		return $this->is_valid_preview;
 	}
-	
+
 	/**
 	 * `true` iff the current request is a preview and the preview is valid.
 	 * ATTENTION: this method is DEPRECATED, use `$this->isValidPreview()`
@@ -891,11 +892,11 @@ class Comments implements Iterator, Countable
 	{
 		return $this->isValidPreview();
 	}
-	
+
 	//
 	// Converter
 	//
-	
+
 	/**
 	 * Returns the comments managed by this `Comments` instance sorted in
 	 * chronological order.
@@ -906,19 +907,19 @@ class Comments implements Iterator, Countable
 	{
 		return $this->comments;
 	}
-	
+
 	/**
 	 * Nests comments based on a reference-to-anchor relationship.
-	 * 
+	 *
 	 * The anchor must be unique for every comment while zero or more references
 	 * may point to the same anchor. A comment is added as a child iff its
 	 * reference matches the anchor of another comment. A comment may not
 	 * reference its own anchor. If the reference of a comment does not match any
 	 * anchor it is placed at the top level.
-	 * 
+	 *
 	 * If `$reference_field` or `$anchor_field` are `null`, the comment’s ID is
 	 * used instead.
-	 * 
+	 *
 	 * By default, the string value of the reference and the anchor are compared.
 	 * Set `$compare_stringvalue` to `false` to compare the original values.
 	 *
@@ -933,35 +934,35 @@ class Comments implements Iterator, Countable
 		$nested_comments = array();
 		/** @var NestedComment[mixed] */
 		$labeled_comments = array();
-		
+
 		foreach ($this->comments as $comment) {
 			$anchor = $anchor_field === null ? $comment->id() : $comment->customField($anchor_field);
 			if ($anchor === null) { continue; }
 			if ($compare_stringvalue) { $anchor = strval($anchor); }
-			
+
 			$labeled_comments[$anchor] = new NestedComment($comment);
 		}
-		
+
 		foreach ($this->comments as $comment) {
 			$anchor = $anchor_field === null ? $comment->id() : $comment->customField($anchor_field);
 			if ($anchor === null) { continue; }
 			$reference = $reference_field === null ? $comment->id() : $comment->customField($reference_field);
 			if ($compare_stringvalue) { $reference = strval($reference); }
-			
+
 			if ($reference !== null && isset($labeled_comments[$reference])) {
 				$labeled_comments[$reference]->addChild($labeled_comments[$anchor]);
 			} else {
 				$nested_comments[] = $labeled_comments[$anchor];
 			}
 		}
-		
+
 		return $nested_comments;
 	}
-	
+
 	//
 	// Properties
 	//
-	
+
 	/**
 	 * Kirby page on which the comments are posted.
 	 *
@@ -971,34 +972,34 @@ class Comments implements Iterator, Countable
 	{
 		return $this->page;
 	}
-	
+
 	//
 	// Iterator
 	//
-	
+
 	function rewind()
 	{
 		$this->iterator_index = 0;
 	}
-	
+
 	function current()
 	{
 		return $this->comments[$this->iterator_index];
 	}
-	
+
 	function key()
 	{
 		return $this->iterator_index;
 	}
-	
+
 	function next()
 	{
 		$this->iterator_index += 1;
 	}
-	
+
 	function valid()
 	{
 		return isset($this->comments[$this->iterator_index]);
 	}
-	
+
 }

--- a/plugin/CommentsEmail.php
+++ b/plugin/CommentsEmail.php
@@ -2,10 +2,10 @@
 
 /**
  * CommentsEmail
- *
+ * 
  * Data and mechanisms used to send email notifications about new comments to
  * a list of recipients.
- *
+ * 
  * @package   Kirby Comments
  * @author    Florian Pircher <florian@addpixel.net>
  * @link      https://addpixel.net/kirby-comments/
@@ -20,7 +20,7 @@ class CommentsEmail
 	 * @var string[]
 	 */
 	private $to;
-
+	
 	/**
 	 * 'From' email address.
 	 *
@@ -28,37 +28,37 @@ class CommentsEmail
 	 */
 	private $from;
 
-	/**
+/**
 	 * Subject of the email. May contain placeholders.
 	 *
 	 * @var string
 	 */
 	private $subject;
-
+	
 	/**
 	 * Message of the email. May contain placeholders.
 	 *
 	 * @var string
 	 */
 	private $message;
-
+	
 	/**
 	 * Status of the email.
 	 *
 	 * @var CommentsStatus
 	 */
 	private $status;
-
+	
 	/**
 	 * Comment about which the email informs the list of recipients.
 	 *
 	 * @var Comment
 	 */
 	private $comment;
-
+	
 	/**
 	 * CommentsEmail constructor.
-	 *
+	 * 
 	 * @param string[] $to
 	 * @param string $subject
 	 * @param Comment $comment
@@ -72,7 +72,7 @@ class CommentsEmail
 		$this->status = new CommentsStatus(0);
 		$this->subject = CommentsEmail::format($comment, $subject);
 	}
-
+	
 	/**
 	 * Replaces placeholders of the pattern `{{ some.key }}` with the
 	 * corresponding value using the data of a comment.
@@ -91,11 +91,11 @@ class CommentsEmail
 			'page.title' => Comments::invokeHook('get-content-page-title', array($comment->page())),
 			'page.url' => $comment->page()->url()
 		);
-
+		
 		return preg_replace_callback('/\{\{\s*(\S+?)\s*\}\}/', function ($matches) use ($placeholders)
 		{
 			$identifier = $matches[1];
-
+			
 			if ($placeholders[$identifier]) {
 				return $placeholders[$identifier];
 			} else {
@@ -103,7 +103,7 @@ class CommentsEmail
 			}
 		}, $text);
 	}
-
+	
 	/**
 	 * Send the email to the recipients.
 	 *
@@ -114,19 +114,20 @@ class CommentsEmail
 		$template_file = 'email.template.txt';
 		$plugin_template_file = __DIR__.'/../assets/'.$template_file;
 		$custom_template_file = __DIR__.'/../../../../assets/plugins/comments/'.$template_file;
-
+		
 		if (file_exists($custom_template_file)) {
 			$template = file_get_contents($custom_template_file);
 		} else {
 			$template = file_get_contents($plugin_template_file);
 		}
-
+		
 		if ($template === false) {
 			return new CommentsStatus(202);
 		}
-
+		
 		$body = CommentsEmail::format($this->comment, $template);
-
+		$headers = 'Content-type: text/plain; charset=utf-8';
+		
 		foreach ( $this->to as $to ) {
 
 			$email = email( array(
@@ -139,9 +140,9 @@ class CommentsEmail
 			if ( ! $email->send() ) {
 				return new CommentsStatus( 203 );
 			}
-
+			
 		}
-
+		
 		return $this->status;
 	}
 }

--- a/plugin/CommentsEmail.php
+++ b/plugin/CommentsEmail.php
@@ -2,10 +2,10 @@
 
 /**
  * CommentsEmail
- * 
+ *
  * Data and mechanisms used to send email notifications about new comments to
  * a list of recipients.
- * 
+ *
  * @package   Kirby Comments
  * @author    Florian Pircher <florian@addpixel.net>
  * @link      https://addpixel.net/kirby-comments/
@@ -20,51 +20,59 @@ class CommentsEmail
 	 * @var string[]
 	 */
 	private $to;
-	
+
+	/**
+	 * 'From' email address.
+	 *
+	 * @var string
+	 */
+	private $from;
+
 	/**
 	 * Subject of the email. May contain placeholders.
 	 *
 	 * @var string
 	 */
 	private $subject;
-	
+
 	/**
 	 * Message of the email. May contain placeholders.
 	 *
 	 * @var string
 	 */
 	private $message;
-	
+
 	/**
 	 * Status of the email.
 	 *
 	 * @var CommentsStatus
 	 */
 	private $status;
-	
+
 	/**
 	 * Comment about which the email informs the list of recipients.
 	 *
 	 * @var Comment
 	 */
 	private $comment;
-	
+
 	/**
 	 * CommentsEmail constructor.
-	 * 
+	 *
 	 * @param string[] $to
 	 * @param string $subject
 	 * @param Comment $comment
 	 */
-	function __construct($to, $subject, $comment)
+	function __construct($to, $from, $subject, $comment)
 	{
 		$this->comment = $comment;
 		$this->to = $to;
+		$this->from = $from;
 		$this->message = strip_tags($comment->message());
 		$this->status = new CommentsStatus(0);
 		$this->subject = CommentsEmail::format($comment, $subject);
 	}
-	
+
 	/**
 	 * Replaces placeholders of the pattern `{{ some.key }}` with the
 	 * corresponding value using the data of a comment.
@@ -83,11 +91,11 @@ class CommentsEmail
 			'page.title' => Comments::invokeHook('get-content-page-title', array($comment->page())),
 			'page.url' => $comment->page()->url()
 		);
-		
+
 		return preg_replace_callback('/\{\{\s*(\S+?)\s*\}\}/', function ($matches) use ($placeholders)
 		{
 			$identifier = $matches[1];
-			
+
 			if ($placeholders[$identifier]) {
 				return $placeholders[$identifier];
 			} else {
@@ -95,7 +103,7 @@ class CommentsEmail
 			}
 		}, $text);
 	}
-	
+
 	/**
 	 * Send the email to the recipients.
 	 *
@@ -106,26 +114,34 @@ class CommentsEmail
 		$template_file = 'email.template.txt';
 		$plugin_template_file = __DIR__.'/../assets/'.$template_file;
 		$custom_template_file = __DIR__.'/../../../../assets/plugins/comments/'.$template_file;
-		
+
 		if (file_exists($custom_template_file)) {
 			$template = file_get_contents($custom_template_file);
 		} else {
 			$template = file_get_contents($plugin_template_file);
 		}
-		
+
 		if ($template === false) {
 			return new CommentsStatus(202);
 		}
-		
+
 		$body = CommentsEmail::format($this->comment, $template);
-		$headers = 'Content-type: text/plain; charset=utf-8';
-		
-		foreach ($this->to as $to) {
-			if (!mail($to, $this->subject, $body, $headers)) {
-				return new CommentsStatus(203);
+
+		foreach ( $this->to as $to ) {
+
+			$email = email( array(
+				'to'      => $to,
+				'from'    => $this->from,
+				'subject' => $this->subject,
+				'body'    => $body
+			 ) );
+
+			if ( ! $email->send() ) {
+				return new CommentsStatus( 203 );
 			}
+
 		}
-		
+
 		return $this->status;
 	}
 }


### PR DESCRIPTION
Hi

I've made a small change so that comment notification emails are sent with Kirby’s `email()` function instead of PHP’s `mail()` function. 

This makes it possible for users to specify their preferred mail service (e.g. SES, Postmark, etc), API keys and other email configuration options (as per https://getkirby.com/docs/developer-guide/advanced/emails).

(Apologies for all the changed blank lines, I think they are caused by my editor automatically stripping out trailing spaces)